### PR TITLE
Defer creation of expensive loggers and guid lookup table 

### DIFF
--- a/Mods/Scribe/ScriptExtender/Lua/Lib/Aahz/Client/Classes/ScribeLogger.lua
+++ b/Mods/Scribe/ScriptExtender/Lua/Lib/Aahz/Client/Classes/ScribeLogger.lua
@@ -14,6 +14,7 @@ function ScribeLogger:Init()
     self:CreateWindow()
     self:InitializeLayout()
 end
+
 function ScribeLogger:CreateWindow()
     if self.Window ~= nil then return end -- only create once
     self.Window = Imgui.CreateCommonWindow("Scribe Log (WIP)", {
@@ -41,7 +42,7 @@ function ScribeLogger:CreateWindow()
             self.MainMenu.UserData.SubMenus[menu.Handle] = menu
         end,
         ActivateSubMenu = function(menu)
-            for _,v in pairs(self.MainMenu.UserData.SubMenus) do
+            for _, v in pairs(self.MainMenu.UserData.SubMenus) do
                 v.Visible = (v.Handle == menu.Handle)
             end
         end
@@ -58,14 +59,35 @@ function ScribeLogger:InitializeLayout()
     self.MainTabBar = self.Window:AddTabBar("Scribe_LoggerTabBar")
     -- self.MainTabBar.AutoSelectNewTabs = true
 
+    -- Create tabs but defer logger initialization until first activation
     self.TabECS = self.MainTabBar:AddTabItem("ECS")
-    self.LoggerECS = ImguiECSLogger:New{}
-    self.LoggerECS:CreateTab(self.TabECS, self.MainMenu)
+    self.TabECS.OnActivate = function()
+        if not self.LoggerECS then
+            self.LoggerECS = ImguiECSLogger:New {}
+            self.LoggerECS:CreateTab(self.TabECS, self.MainMenu)
+            self.MainMenu.UserData.ActivateSubMenu(self.LoggerECS.SettingsMenu)
+        else
+            -- If already initialized, just activate submenu
+            if self.LoggerECS.SettingsMenu then
+                self.MainMenu.UserData.ActivateSubMenu(self.LoggerECS.SettingsMenu)
+            end
+        end
+    end
 
     self.TabServerEvents = self.MainTabBar:AddTabItem("Server Events")
-    self.LoggerServerEvents = ImguiServerEventLogger:New{}
-    self.LoggerServerEvents:CreateTab(self.TabServerEvents, self.MainMenu)
-    self.MainMenu.UserData.ActivateSubMenu(self.LoggerECS.SettingsMenu)
+    self.TabServerEvents.OnActivate = function()
+        if not self.LoggerServerEvents then
+            self.LoggerServerEvents = ImguiServerEventLogger:New {}
+            self.LoggerServerEvents:CreateTab(self.TabServerEvents, self.MainMenu)
+            if self.LoggerServerEvents.SettingsMenu then
+                self.MainMenu.UserData.ActivateSubMenu(self.LoggerServerEvents.SettingsMenu)
+            end
+        else
+            if self.LoggerServerEvents.SettingsMenu then
+                self.MainMenu.UserData.ActivateSubMenu(self.LoggerServerEvents.SettingsMenu)
+            end
+        end
+    end
 
     self.Ready = true
 end

--- a/Mods/Scribe/ScriptExtender/Lua/Lib/Aahz/Shared/Classes/GuidLookup.lua
+++ b/Mods/Scribe/ScriptExtender/Lua/Lib/Aahz/Shared/Classes/GuidLookup.lua
@@ -15,21 +15,28 @@ local GuidLookup = {
     LookupMap = {},
 }
 
+
 ---Retrieves a known resource based on Guid
 ---@param guid Guid
 ---@return ResourceGuidResource|ResourceResource|nil
 function GuidLookup:Lookup(guid)
-    if not self.Ready or not guid then return end
+    if not self.Ready then
+        GuidLookup._Initialize()
+    end
+    if not guid then return end
     local lookup = self.LookupMap[guid]
     if lookup then
         return Ext[lookup.Location].Get(guid, lookup.ResourceType)
     end
 end
+
 function GuidLookup._Initialize()
+    -- Note: some mods might edit these resources after initialization, but not worth the overhead to re-scan
+    if GuidLookup.Ready then return end
     ---@param rmt GuidResourceType
-    for _,rmt in ipairs(Ext.Enums.ExtResourceManagerType) do
+    for _, rmt in ipairs(Ext.Enums.ExtResourceManagerType) do
         if rmt == "Max" then break end
-        for _,guid in ipairs(Ext.StaticData.GetAll(rmt)) do
+        for _, guid in ipairs(Ext.StaticData.GetAll(rmt)) do
             if guid ~= NULLUUID then
                 GuidLookup.LookupMap[guid] = {
                     Location = "StaticData",
@@ -38,9 +45,9 @@ function GuidLookup._Initialize()
             end
         end
     end
-    for _,rbt in ipairs(Ext.Enums.ResourceBankType) do
+    for _, rbt in ipairs(Ext.Enums.ResourceBankType) do
         if rbt == "Sentinel" then break end
-        for _,guid in ipairs(Ext.Resource.GetAll(rbt)) do
+        for _, guid in ipairs(Ext.Resource.GetAll(rbt)) do
             if guid ~= NULLUUID then
                 GuidLookup.LookupMap[guid] = {
                     Location = "Resource",
@@ -51,6 +58,5 @@ function GuidLookup._Initialize()
     end
     GuidLookup.Ready = true
 end
-GuidLookup._Initialize()
 
 return GuidLookup


### PR DESCRIPTION
These operations can incur costs of hundreds of milliseconds, and this refactor limits that to when they are actually needed (i.e. doing a lookup or opening the ECS logger tab)