### PR TITLE
Correctly assign null UUID string to `PersonalStatusImmunities` component

### DIFF
--- a/Mods/Scribe/ScriptExtender/Lua/Lib/Aahz/Server/_Init.lua
+++ b/Mods/Scribe/ScriptExtender/Lua/Lib/Aahz/Server/_Init.lua
@@ -9,9 +9,9 @@ Ext.Events.SessionLoaded:Subscribe(function()
     local annoyingHelperID = "783884b2-fbee-4376-9c18-6fd99d225ce6"
     local annoyingHelper = Ext.Entity.Get(annoyingHelperID)
     if annoyingHelper ~= nil then
-        annoyingHelper.StatusImmunities.PersonalStatusImmunities["BURNING"] = nil
-        annoyingHelper.StatusImmunities.PersonalStatusImmunities["BURNING_LAVA"] = nil
-        annoyingHelper.StatusImmunities.PersonalStatusImmunities["SG_Condition"] = nil
+        annoyingHelper.StatusImmunities.PersonalStatusImmunities["BURNING"] = { NULLUUID }
+        annoyingHelper.StatusImmunities.PersonalStatusImmunities["BURNING_LAVA"] = { NULLUUID }
+        annoyingHelper.StatusImmunities.PersonalStatusImmunities["SG_Condition"] = { NULLUUID }
         annoyingHelper:Replicate("StatusImmunities")
     end
 end)

--- a/Mods/Scribe/ScriptExtender/Lua/Lib/Aahz/Server/_Init.lua
+++ b/Mods/Scribe/ScriptExtender/Lua/Lib/Aahz/Server/_Init.lua
@@ -9,9 +9,9 @@ Ext.Events.SessionLoaded:Subscribe(function()
     local annoyingHelperID = "783884b2-fbee-4376-9c18-6fd99d225ce6"
     local annoyingHelper = Ext.Entity.Get(annoyingHelperID)
     if annoyingHelper ~= nil then
-        annoyingHelper.StatusImmunities.PersonalStatusImmunities["BURNING"] = NULLUUID
-        annoyingHelper.StatusImmunities.PersonalStatusImmunities["BURNING_LAVA"] = NULLUUID
-        annoyingHelper.StatusImmunities.PersonalStatusImmunities["SG_Condition"] = NULLUUID
+        annoyingHelper.StatusImmunities.PersonalStatusImmunities["BURNING"] = nil
+        annoyingHelper.StatusImmunities.PersonalStatusImmunities["BURNING_LAVA"] = nil
+        annoyingHelper.StatusImmunities.PersonalStatusImmunities["SG_Condition"] = nil
         annoyingHelper:Replicate("StatusImmunities")
     end
 end)

--- a/Mods/Scribe/meta.lsx
+++ b/Mods/Scribe/meta.lsx
@@ -7,7 +7,7 @@
         <node id="ModuleInfo">
           <attribute id="UUID" type="FixedString" value="84b2cdba-ad21-4d8c-97d6-c09b95a6d9b4" />
           <attribute id="Name" type="LSString" value="Scribe" />
-          <attribute id="Author" type="LSString" value="Skiz, Satan, Aahz and Norbyte" />
+          <attribute id="Author" type="LSString" value="Skiz, Satan, Aahz, Norbyte, Volitio" />
           <attribute id="Description" type="LSString" value="Mousover Inspector" />
           <attribute id="Folder" type="LSString" value="Scribe" />
           <attribute id="CharacterCreationLevelName" type="FixedString" value="" />
@@ -20,10 +20,10 @@
           <attribute id="StartupLevelName" type="FixedString" value="" />
           <attribute id="Tags" type="LSString" value="" />
           <attribute id="Type" type="FixedString" value="" />
-          <attribute id="Version64" type="int64" value="72198331526283264" />
+          <attribute id="Version64" type="int64" value="72339069014638592" />
           <children>
             <node id="PublishVersion">
-              <attribute id="Version64" type="int64" value="72198331526283264" />
+              <attribute id="Version64" type="int64" value="72339069014638592" />
             </node>
             <node id="TargetModes">
               <children>


### PR DESCRIPTION
`PersonalStatusImmunities` is a ⁨`HashMap<FixedString, Array<Guid>>⁩`, assigning a string won't work and was throwing exceptions.